### PR TITLE
Make Datatable.prototype.replace, actually replace selector's html content.

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ DataTable.prototype.render = function(){
  */
 
 DataTable.prototype.replace = function(el){
-  o(el).append(this.render());
+  o(el).html(this.render());
 };
 
 /**


### PR DESCRIPTION
- Changed `jQuery.append` for `jQuery.html` on `Datatable.prototype.replace` method.
